### PR TITLE
Resolve the issue of adb remount

### DIFF
--- a/libkernelflinger/trusty_common.c
+++ b/libkernelflinger/trusty_common.c
@@ -116,9 +116,13 @@ EFI_STATUS load_tos_image(OUT VOID **bootimage)
         AvbSlotVerifyData *slot_data;
         BOOLEAN b_secureboot = is_platform_secure_boot_enabled();
 
-        if (!b_secureboot) {
+        if (!b_secureboot)
                 verify_state = BOOT_STATE_ORANGE;
-        }
+#ifndef USER
+        if (device_is_unlocked())
+                verify_state = BOOT_STATE_ORANGE;
+#endif
+
         verify_state_new = verify_state;
 
         ret = android_image_load_partition_avb("tos", bootimage, &verify_state_new, &slot_data);  // Do not try to switch slot if failed

--- a/libkernelflinger/trusty_common.c
+++ b/libkernelflinger/trusty_common.c
@@ -112,21 +112,22 @@ EFI_STATUS load_tos_image(OUT VOID **bootimage)
 {
         EFI_STATUS ret;
         UINT8 verify_state = BOOT_STATE_GREEN;
+        UINT8 verify_state_new;
         AvbSlotVerifyData *slot_data;
         BOOLEAN b_secureboot = is_platform_secure_boot_enabled();
 
-        if (device_is_unlocked() || !b_secureboot) {
+        if (!b_secureboot) {
                 verify_state = BOOT_STATE_ORANGE;
         }
+        verify_state_new = verify_state;
 
-
-        ret = android_image_load_partition_avb("tos", bootimage, &verify_state, &slot_data);  // Do not try to switch slot if failed
+        ret = android_image_load_partition_avb("tos", bootimage, &verify_state_new, &slot_data);  // Do not try to switch slot if failed
         if (EFI_ERROR(ret)) {
                 efi_perror(ret, L"TOS image loading failed");
                 return ret;
         }
 
-        if (verify_state != BOOT_STATE_GREEN) {
+        if (verify_state != verify_state_new) {
 #ifndef USERDEBUG
                 error(L"Invalid TOS image. Boot anyway on ENG build");
                 ret = EFI_SUCCESS;


### PR DESCRIPTION
If the secure boot is disabled, then ignore verify TOS failed.

