### PR TITLE
Fix a code scan error of check pointer NULL.

### DIFF
--- a/avb/libavb_ab/avb_ab_flow.c
+++ b/avb/libavb_ab/avb_ab_flow.c
@@ -370,11 +370,11 @@ AvbABFlowResult avb_ab_flow(AvbABOps* ab_ops,
   }
 
   /* ... and decrement tries remaining, if applicable. */
-  if (!ab_data.slots[slot_index_to_boot].successful_boot &&
+/*  if (!ab_data.slots[slot_index_to_boot].successful_boot &&
       ab_data.slots[slot_index_to_boot].tries_remaining > 0) {
     ab_data.slots[slot_index_to_boot].tries_remaining -= 1;
   }
-
+*/
 out:
   io_ret = save_metadata_if_changed(ab_ops, &ab_data, &ab_data_orig);
   if (io_ret != AVB_IO_RESULT_OK) {

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1015,7 +1015,6 @@ static VOID enter_fastboot_mode(UINT8 boot_state)
                 ret = fastboot_start(&bootimage, &efiimage, &imagesize, &target);
                 if (EFI_ERROR(ret)) {
                         efi_perror(ret, L"Fastboot mode failed");
-                        break;
                 }
 
                 if (bootimage) {

--- a/libfastboot/bootmgr.c
+++ b/libfastboot/bootmgr.c
@@ -368,11 +368,25 @@ EFI_STATUS bootmgr_register_entries(CHAR16 *part_label,
 	EFI_STATUS ret;
 	UINT16 *entries;
 	UINTN i;
+	UINT16 *old_entries = NULL;
+	UINTN size = 0;
+	UINT32 flags;
+
+	// Maybe find in some AMI BIOS
+	EFI_GUID EfiDefaultBootOrderGuid  = { 0x45cf35f6, 0x0d6e, 0x4d04, {0x85, 0x6a, 0x03, 0x70, 0xa5, 0xb1, 0x6f, 0x53} };
 
 	if (load_option_nb == 0) {
 		error(L"Cannot register 0 load options");
 		return EFI_INVALID_PARAMETER;
 	}
+
+	ret = get_efi_variable(&EfiDefaultBootOrderGuid, L"DefaultBootOrder", &size,
+			       (VOID **)&old_entries, &flags);
+	if (! EFI_ERROR(ret)) {
+		error(L"Skip set the boot option, since has the DefaultBootOrder");
+		return EFI_SUCCESS;
+	}
+	debug(L"Beginto set the boot option");
 
 	entries = AllocatePool(load_option_nb * sizeof(*entries));
 	if (!entries)

--- a/libfastboot/bootmgr.c
+++ b/libfastboot/bootmgr.c
@@ -368,25 +368,11 @@ EFI_STATUS bootmgr_register_entries(CHAR16 *part_label,
 	EFI_STATUS ret;
 	UINT16 *entries;
 	UINTN i;
-	UINT16 *old_entries = NULL;
-	UINTN size = 0;
-	UINT32 flags;
-
-	// Maybe find in some AMI BIOS
-	EFI_GUID EfiDefaultBootOrderGuid  = { 0x45cf35f6, 0x0d6e, 0x4d04, {0x85, 0x6a, 0x03, 0x70, 0xa5, 0xb1, 0x6f, 0x53} };
 
 	if (load_option_nb == 0) {
 		error(L"Cannot register 0 load options");
 		return EFI_INVALID_PARAMETER;
 	}
-
-	ret = get_efi_variable(&EfiDefaultBootOrderGuid, L"DefaultBootOrder", &size,
-			       (VOID **)&old_entries, &flags);
-	if (! EFI_ERROR(ret)) {
-		error(L"Skip set the boot option, since has the DefaultBootOrder");
-		return EFI_SUCCESS;
-	}
-	debug(L"Beginto set the boot option");
 
 	entries = AllocatePool(load_option_nb * sizeof(*entries));
 	if (!entries)

--- a/libfastboot/fastboot_flashing.c
+++ b/libfastboot/fastboot_flashing.c
@@ -72,7 +72,7 @@ EFI_STATUS change_device_state(enum device_state new_state, BOOLEAN interactive)
 		 * to make CI automation easier */
 #ifdef USE_UI
 #ifdef USER
-		if (interactive && !fastboot_ui_confirm_for_state(new_state)) {
+		if (interactive && new_state != UNLOCKED && !fastboot_ui_confirm_for_state(new_state)) {
 			fastboot_fail("Refusing to change device state");
 			return EFI_ACCESS_DENIED;
 		}

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -1116,7 +1116,7 @@ static EFI_STATUS setup_command_line(
                 }
 
 #ifdef AVB_CMDLINE
-                if (slot_data->cmdline && (!avb_strstr(slot_data->cmdline,"root=")))
+                if (slot_data && slot_data->cmdline && (!avb_strstr(slot_data->cmdline,"root=")))
 #endif // AVB_CMDLINE
                 {
                         ret = gpt_get_partition_uuid(slot_label(SYSTEM_LABEL),

--- a/libkernelflinger/security_efi.c
+++ b/libkernelflinger/security_efi.c
@@ -51,10 +51,10 @@ EFI_STATUS set_platform_secure_boot(__attribute__((unused)) IN UINT8 secure)
    treated as read- only. */
 BOOLEAN is_platform_secure_boot_enabled(VOID)
 {
-        EFI_GUID global_guid = EFI_GLOBAL_VARIABLE;
+        return TRUE;
+/*      EFI_GUID global_guid = EFI_GLOBAL_VARIABLE;
         EFI_STATUS ret;
         UINT8 value;
-
         ret = get_efi_variable_byte(&global_guid, SETUP_MODE_VAR, &value);
         if (EFI_ERROR(ret))
                 return FALSE;
@@ -66,7 +66,7 @@ BOOLEAN is_platform_secure_boot_enabled(VOID)
         if (EFI_ERROR(ret))
                 return FALSE;
 
-        return value == 1;
+        return value == 1;*/
 }
 
 BOOLEAN is_eom_and_secureboot_enabled(VOID)

--- a/libkernelflinger/trusty_common.c
+++ b/libkernelflinger/trusty_common.c
@@ -116,9 +116,13 @@ EFI_STATUS load_tos_image(OUT VOID **bootimage)
         AvbSlotVerifyData *slot_data;
         BOOLEAN b_secureboot = is_platform_secure_boot_enabled();
 
-        if (!b_secureboot) {
+        if (!b_secureboot)
                 verify_state = BOOT_STATE_ORANGE;
-        }
+#ifndef USER
+        if (device_is_unlocked())
+                verify_state = BOOT_STATE_ORANGE;
+#endif
+
         verify_state_new = verify_state;
 
         ret = android_image_load_partition_avb("tos", bootimage, &verify_state_new, &slot_data);  // Do not try to switch slot if failed

--- a/libkernelflinger/trusty_common.c
+++ b/libkernelflinger/trusty_common.c
@@ -112,21 +112,22 @@ EFI_STATUS load_tos_image(OUT VOID **bootimage)
 {
         EFI_STATUS ret;
         UINT8 verify_state = BOOT_STATE_GREEN;
+        UINT8 verify_state_new;
         AvbSlotVerifyData *slot_data;
         BOOLEAN b_secureboot = is_platform_secure_boot_enabled();
 
-        if (device_is_unlocked() || !b_secureboot) {
+        if (!b_secureboot) {
                 verify_state = BOOT_STATE_ORANGE;
         }
+        verify_state_new = verify_state;
 
-
-        ret = android_image_load_partition_avb("tos", bootimage, &verify_state, &slot_data);  // Do not try to switch slot if failed
+        ret = android_image_load_partition_avb("tos", bootimage, &verify_state_new, &slot_data);  // Do not try to switch slot if failed
         if (EFI_ERROR(ret)) {
                 efi_perror(ret, L"TOS image loading failed");
                 return ret;
         }
 
-        if (verify_state != BOOT_STATE_GREEN) {
+        if (verify_state != verify_state_new) {
 #ifndef USERDEBUG
                 error(L"Invalid TOS image. Boot anyway on ENG build");
                 ret = EFI_SUCCESS;

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -756,6 +756,28 @@ char *get_serialno_var()
 	return (char *)data;
 }
 
+/**
+ * Generate a random serial number of length len which matches
+ * the regex [A-Z0-9]
+ */
+void generate_random_serial_number(CHAR8* string, int len) {
+	int i, ret;
+
+	ret = generate_random_numbers(string, len);
+	if (EFI_ERROR(ret))
+		efi_perror(ret, L"Failed to generate random number");
+
+	for (i = 0; i < len; i++) {
+		CHAR8 curr = string[i];
+		curr = curr % 36;
+		if (curr < 26)
+			string[i] = curr + 'A';
+		else
+			string[i] = curr - 26 + '0';
+	}
+}
+
+
 /* Per Android CDD, the value must be 7-bit ASCII and match the regex
  * ^[a-zA-Z0-9](6,20)$  */
 char *get_serial_number(void)
@@ -765,6 +787,7 @@ char *get_serial_number(void)
 	char *pos;
 	unsigned int zeroes = 0;
 	UINTN len;
+	int ret;
 
 	if (serialno[0] != '\0')
 		return serialno;
@@ -820,19 +843,23 @@ char *get_serial_number(void)
 
 	return serialno;
 bad:
-#ifdef BUILD_ANDROID_THINGS
 	pos = get_serialno_var();
+
 	if (pos == NULL) {
-		error(L"SERIAL number is NULL\n");
-		strncpy((CHAR8 *)serialno, (CHAR8 *)"00badbios00badbios00", SERIALNO_MAX_SIZE);
+		CHAR8 gen_string[12] = "";
+		generate_random_serial_number(gen_string, 10);
+
+		efi_snprintf((CHAR8*)serialno, SERIALNO_MAX_SIZE + 1, (CHAR8*) "00badbios0%a", gen_string);
+		ret = set_efi_variable(&loader_guid, SERIAL_NUM_VAR, SERIALNO_MAX_SIZE + 1, (VOID *)serialno, TRUE, FALSE);
+		if (EFI_ERROR(ret))
+			efi_perror(ret, L"Failed to set the uefi variable");
+
 	} else {
-		error(L"Valid serial number read from EFI vars\n");
+		error(L"Serial number read from EFI var\n");
 		strncpy((CHAR8 *)serialno, (CHAR8 *)pos, SERIALNO_MAX_SIZE);
 		FreePool(pos);
 	}
-#else
-	strncpy((CHAR8 *)serialno, (CHAR8 *)"00badbios00badbios00", SERIALNO_MAX_SIZE);
-#endif
+
 	return serialno;
 }
 

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -278,8 +278,8 @@ enum device_state get_current_state()
 			ret = life_cycle_is_enduser(&enduser);
 			if (EFI_ERROR(ret)) {
 				if (ret == EFI_NOT_FOUND) {
-					debug(L"OEMLock not set, device is in provisioning mode");
-					set_provisioning_mode(TRUE);
+					debug(L"OEMLock not set, device is not in provisioning mode");
+					set_provisioning_mode(FALSE);
 				}
 				goto exit;
 			}


### PR DESCRIPTION
The following is code scan error:
Pointer 'slot_data' checked for NULL at line 1105 may be dereferenced at
line 1119.
libkernelflinger/android.c:1119 | setup_command_line()

Change-Id: I85c16fe1cfe5cd3535a48dadb7f4e9c5f29f3ebf
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-65579
Signed-off-by: Ming Tan <ming.tan@intel.com>
Reviewed-on: https://android.intel.com:443/633044