### PR TITLE
Install ACPI talbe before trusty started

### DIFF
--- a/include/libkernelflinger/android.h
+++ b/include/libkernelflinger/android.h
@@ -261,6 +261,8 @@ EFI_STATUS android_image_start_buffer(
 #endif
                 IN const CHAR8 *abl_cmd_line);
 
+EFI_STATUS setup_acpi_table(VOID *bootimage, enum boot_target target);
+
 EFI_STATUS android_image_load_partition(
                 IN const CHAR16 *label,
                 OUT VOID **bootimage_p);

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -953,6 +953,13 @@ static EFI_STATUS load_image(VOID *bootimage, UINT8 boot_state,
                 efi_perror(ret, L"Failed to set os secure boot");
 #endif
 
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
+
 #ifdef USE_TRUSTY
         if (is_bootimg_target(boot_target) || boot_target == MEMORY) {
 

--- a/kf4abl.c
+++ b/kf4abl.c
@@ -931,6 +931,14 @@ EFI_STATUS avb_boot_android(enum boot_target boot_target, CHAR8 *abl_cmd_line)
 	}
 
 	set_boottime_stamp(TM_VERIFY_BOOT_DONE);
+
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
+
 #ifdef USE_TRUSTY
 	if (boot_target == NORMAL_BOOT) {
 		VOID *tosimage = NULL;
@@ -1011,6 +1019,13 @@ EFI_STATUS boot_android(enum boot_target boot_target, CHAR8 *abl_cmd_line)
 		goto exit;
 	}
 	set_boottime_stamp(TM_VERIFY_BOOT_DONE);
+
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
 
 #ifdef USE_TRUSTY
 	if (boot_target == NORMAL_BOOT) {

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -552,8 +552,8 @@ static EFI_STATUS setup_ramdisk(UINT8 *bootimage)
 }
 
 
-static EFI_STATUS setup_acpi_table(VOID *bootimage,
-                                   __attribute__((__unused__)) enum boot_target target)
+EFI_STATUS setup_acpi_table(VOID *bootimage,
+                            __attribute__((__unused__)) enum boot_target target)
 {
         struct boot_img_hdr *aosp_header;
 
@@ -1996,12 +1996,6 @@ EFI_STATUS android_image_start_buffer(
         if (memcmp(aosp_header->magic, BOOT_MAGIC, BOOT_MAGIC_SIZE)) {
                 error(L"buffer does not appear to contain an Android boot image");
                 return EFI_INVALID_PARAMETER;
-        }
-
-        ret = setup_acpi_table(bootimage, boot_target);
-        if (EFI_ERROR(ret)) {
-                efi_perror(ret, L"setup_acpi_table");
-                return ret;
         }
 
         buf = (struct boot_params *)(bootimage + aosp_header->page_size);


### PR DESCRIPTION
after trusty started, install ACPI table for early mount cause
kernelflinger crash

Change-Id: I3f349db32c9ea74c51c8a31e4a3ab6c732537735
Tracked-On: OAM-72091
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>