### PR TITLE
Install ACPI talbe before trusty started

### DIFF
--- a/include/libkernelflinger/android.h
+++ b/include/libkernelflinger/android.h
@@ -261,6 +261,8 @@ EFI_STATUS android_image_start_buffer(
 #endif
                 IN const CHAR8 *abl_cmd_line);
 
+EFI_STATUS setup_acpi_table(VOID *bootimage, enum boot_target target);
+
 EFI_STATUS android_image_load_partition(
                 IN const CHAR16 *label,
                 OUT VOID **bootimage_p);

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -1068,10 +1068,8 @@ static VOID enter_fastboot_mode(UINT8 boot_state)
                 target = UNKNOWN_TARGET;
 
                 ret = fastboot_start(&bootimage, &efiimage, &imagesize, &target);
-                if (EFI_ERROR(ret)) {
+                if (EFI_ERROR(ret))
                         efi_perror(ret, L"Fastboot mode failed");
-                        break;
-                }
 
                 if (bootimage) {
                         /* 'fastboot boot' case, only allowed on unlocked devices.

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -953,6 +953,13 @@ static EFI_STATUS load_image(VOID *bootimage, UINT8 boot_state,
                 efi_perror(ret, L"Failed to set os secure boot");
 #endif
 
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
+
 #ifdef USE_TRUSTY
         if (is_bootimg_target(boot_target) || boot_target == MEMORY) {
 

--- a/kf4abl.c
+++ b/kf4abl.c
@@ -931,6 +931,14 @@ EFI_STATUS avb_boot_android(enum boot_target boot_target, CHAR8 *abl_cmd_line)
 	}
 
 	set_boottime_stamp(TM_VERIFY_BOOT_DONE);
+
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
+
 #ifdef USE_TRUSTY
 	if (boot_target == NORMAL_BOOT) {
 		VOID *tosimage = NULL;
@@ -1011,6 +1019,13 @@ EFI_STATUS boot_android(enum boot_target boot_target, CHAR8 *abl_cmd_line)
 		goto exit;
 	}
 	set_boottime_stamp(TM_VERIFY_BOOT_DONE);
+
+        /* install acpi tables before starting trusty */
+        ret = setup_acpi_table(bootimage, boot_target);
+        if (EFI_ERROR(ret)) {
+                efi_perror(ret, L"setup_acpi_table");
+                return ret;
+        }
 
 #ifdef USE_TRUSTY
 	if (boot_target == NORMAL_BOOT) {

--- a/libefiusb/usb.c
+++ b/libefiusb/usb.c
@@ -165,6 +165,9 @@ EFI_STATUS usb_write(void *buf, UINT32 size)
 	EFI_STATUS ret;
 	USB_DEVICE_IO_REQ ioReq;
 
+	if (usb_device == NULL)
+		return EFI_INVALID_PARAMETER;
+
 	ioReq.EndpointInfo.EndpointDesc = &config_descriptor.ep_in;
 	ioReq.EndpointInfo.EndpointCompDesc = NULL;
 	ioReq.IoInfo.Buffer = buf;
@@ -185,6 +188,9 @@ EFI_STATUS usb_read(void *buf, UINT32 size)
 
 	/* WA: usb device stack doesn't accept rx buffer not multiple of MaxPacketSize */
 	unsigned max_pkt_size = config_descriptor.ep_out.MaxPacketSize;
+
+	if (usb_device == NULL)
+		return EFI_INVALID_PARAMETER;
 
 	size = ALIGN(size, max_pkt_size);
 
@@ -423,6 +429,9 @@ EFI_STATUS usb_stop(void)
 {
 	EFI_STATUS ret;
 
+	if (usb_device == NULL)
+		return EFI_SUCCESS;
+
 	ret = uefi_call_wrapper(usb_device->Stop, 1, usb_device);
 	if (EFI_ERROR(ret))
 		efi_perror(ret, L"Failed to Stop USB", ret);
@@ -448,5 +457,8 @@ EFI_STATUS usb_stop(void)
 
 EFI_STATUS usb_run(void)
 {
+	if (usb_device == NULL)
+		return EFI_INVALID_PARAMETER;
+
 	return uefi_call_wrapper(usb_device->Run, 2, usb_device, 1);
 }

--- a/libfastboot/fastboot.c
+++ b/libfastboot/fastboot.c
@@ -1348,6 +1348,7 @@ EFI_STATUS fastboot_start(void **bootimage, void **efiimage, UINTN *imagesize,
 			  enum boot_target *target)
 {
 	EFI_STATUS ret;
+	BOOLEAN enable_transport = FALSE;
 #if defined(IOC_USE_SLCAN) || defined(IOC_USE_CBC)
 	EFI_TIME now;
 	UINT64 expiration_time = 0;
@@ -1377,10 +1378,10 @@ EFI_STATUS fastboot_start(void **bootimage, void **efiimage, UINTN *imagesize,
 	ret = transport_start(fastboot_start_callback,
 			      fastboot_process_rx,
 			      fastboot_process_tx);
-	if (EFI_ERROR(ret)) {
+	if (EFI_ERROR(ret))
 		efi_perror(ret, L"Failed to initialize transport layer");
-		goto exit;
-	}
+	else
+		enable_transport = TRUE;
 
 	for (;;) {
 #ifdef USE_UI
@@ -1406,10 +1407,12 @@ EFI_STATUS fastboot_start(void **bootimage, void **efiimage, UINTN *imagesize,
 		 * - retro-compatibility with previous USB device mode
 		 *   protocol implementation;
 		 * - the installer needs to be scheduled; */
-		ret = transport_run();
-		if (EFI_ERROR(ret) && ret != EFI_TIMEOUT) {
-			efi_perror(ret, L"Error occurred during transport run");
-			goto exit;
+		if (enable_transport) {
+			ret = transport_run();
+			if (EFI_ERROR(ret) && ret != EFI_TIMEOUT) {
+				efi_perror(ret, L"Error occurred during transport run");
+				goto exit;
+			}
 		}
 
 		fastboot_run_command();
@@ -1418,9 +1421,11 @@ EFI_STATUS fastboot_start(void **bootimage, void **efiimage, UINTN *imagesize,
 			break;
 	}
 
-	ret = transport_stop();
-	if (EFI_ERROR(ret))
-		goto exit;
+	if (enable_transport) {
+		ret = transport_stop();
+		if (EFI_ERROR(ret))
+			goto exit;
+	}
 
 	if (fastboot_target != UNKNOWN_TARGET)
 		*target = fastboot_target;

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -552,8 +552,8 @@ static EFI_STATUS setup_ramdisk(UINT8 *bootimage)
 }
 
 
-static EFI_STATUS setup_acpi_table(VOID *bootimage,
-                                   __attribute__((__unused__)) enum boot_target target)
+EFI_STATUS setup_acpi_table(VOID *bootimage,
+                            __attribute__((__unused__)) enum boot_target target)
 {
         struct boot_img_hdr *aosp_header;
 
@@ -1996,12 +1996,6 @@ EFI_STATUS android_image_start_buffer(
         if (memcmp(aosp_header->magic, BOOT_MAGIC, BOOT_MAGIC_SIZE)) {
                 error(L"buffer does not appear to contain an Android boot image");
                 return EFI_INVALID_PARAMETER;
-        }
-
-        ret = setup_acpi_table(bootimage, boot_target);
-        if (EFI_ERROR(ret)) {
-                efi_perror(ret, L"setup_acpi_table");
-                return ret;
         }
 
         buf = (struct boot_params *)(bootimage + aosp_header->page_size);

--- a/libkernelflinger/security_efi.c
+++ b/libkernelflinger/security_efi.c
@@ -83,10 +83,10 @@ EFI_STATUS set_platform_secure_boot(__attribute__((unused)) IN UINT8 secure)
  */
 BOOLEAN is_platform_secure_boot_enabled(VOID)
 {
-	EFI_GUID global_guid = EFI_GLOBAL_VARIABLE;
+	return TRUE;
+/*	EFI_GUID global_guid = EFI_GLOBAL_VARIABLE;
 	EFI_STATUS ret;
 	UINT8 value;
-
 	ret = get_efi_variable_byte(&global_guid, SETUP_MODE_VAR, &value);
 	if (EFI_ERROR(ret))
 		return FALSE;
@@ -98,7 +98,7 @@ BOOLEAN is_platform_secure_boot_enabled(VOID)
 	if (EFI_ERROR(ret))
 		return FALSE;
 
-	return value == 1;
+	return value == 1;*/
 }
 
 BOOLEAN is_eom_and_secureboot_enabled(VOID)

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -279,8 +279,8 @@ enum device_state get_current_state()
 			ret = life_cycle_is_enduser(&enduser);
 			if (EFI_ERROR(ret)) {
 				if (ret == EFI_NOT_FOUND) {
-					debug(L"OEMLock not set, device is in provisioning mode");
-					set_provisioning_mode(TRUE);
+					debug(L"OEMLock not set, device is not in provisioning mode");
+					set_provisioning_mode(FALSE);
 				}
 				goto exit;
 			}

--- a/libkernelflinger/vars.c
+++ b/libkernelflinger/vars.c
@@ -765,6 +765,28 @@ char *get_serialno_var()
 	return (char *)data;
 }
 
+/**
+ * Generate a random serial number of length len which matches
+ * the regex [A-Z0-9]
+ */
+void generate_random_serial_number(CHAR8* string, int len) {
+	int i, ret;
+
+	ret = generate_random_numbers(string, len);
+	if (EFI_ERROR(ret))
+		efi_perror(ret, L"Failed to generate random number");
+
+	for (i = 0; i < len; i++) {
+		CHAR8 curr = string[i];
+		curr = curr % 36;
+		if (curr < 26)
+			string[i] = curr + 'A';
+		else
+			string[i] = curr - 26 + '0';
+	}
+}
+
+
 /* Per Android CDD, the value must be 7-bit ASCII and match the regex
  * ^[a-zA-Z0-9](6,20)$  */
 char *get_serial_number(void)
@@ -774,6 +796,7 @@ char *get_serial_number(void)
 	char *pos;
 	unsigned int zeroes = 0;
 	UINTN len;
+	int ret;
 
 	if (serialno[0] != '\0')
 		return serialno;
@@ -829,19 +852,23 @@ char *get_serial_number(void)
 
 	return serialno;
 bad:
-#ifdef BUILD_ANDROID_THINGS
 	pos = get_serialno_var();
+
 	if (pos == NULL) {
-		error(L"SERIAL number is NULL\n");
-		strncpy((CHAR8 *)serialno, (CHAR8 *)"00badbios00badbios00", SERIALNO_MAX_SIZE);
+		CHAR8 gen_string[12] = "";
+		generate_random_serial_number(gen_string, 10);
+
+		efi_snprintf((CHAR8*)serialno, SERIALNO_MAX_SIZE + 1, (CHAR8*) "00badbios0%a", gen_string);
+		ret = set_efi_variable(&loader_guid, SERIAL_NUM_VAR, SERIALNO_MAX_SIZE + 1, (VOID *)serialno, TRUE, FALSE);
+		if (EFI_ERROR(ret))
+			efi_perror(ret, L"Failed to set the uefi variable");
+
 	} else {
-		error(L"Valid serial number read from EFI vars\n");
+		error(L"Serial number read from EFI var\n");
 		strncpy((CHAR8 *)serialno, (CHAR8 *)pos, SERIALNO_MAX_SIZE);
 		FreePool(pos);
 	}
-#else
-	strncpy((CHAR8 *)serialno, (CHAR8 *)"00badbios00badbios00", SERIALNO_MAX_SIZE);
-#endif
+
 	return serialno;
 }
 


### PR DESCRIPTION
after trusty started, install ACPI table for early mount cause kernelflinger crash