### PR TITLE
Kernelflinger failed to use simulate RPMB if physical RPMB not found

### DIFF
--- a/libkernelflinger/rpmb/rpmb_storage.c
+++ b/libkernelflinger/rpmb/rpmb_storage.c
@@ -750,6 +750,7 @@ EFI_STATUS rpmb_storage_init(void)
 				}
 				debug(L"Can't find physical RPMB, use simulate RPMB now");
 				real = FALSE;
+				ret = EFI_SUCCESS;
 			}
 		}
 	}


### PR DESCRIPTION
Original design is set the kernelflinger to try physical RPMB at first,
and use simulate RPMB if physical RPMB not found.But kernelflinger
failed to use simulate RPMB if physical RPMB is not found.

Tracked-On: OAM-80064
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>