### PR TITLE
[DO NOT MERGE] Output log to screen for debug.

### DIFF
--- a/include/libkernelflinger/log.h
+++ b/include/libkernelflinger/log.h
@@ -53,8 +53,12 @@ void vlog(const CHAR16 *fmt, va_list args);
 #endif
 
 #if DEBUG_MESSAGES
-#define debug(fmt, ...) do { \
-    log(fmt "\n", ##__VA_ARGS__); \
+#define debug(x, ...) do { \
+  log(x "\n", ##__VA_ARGS__); \
+  if (ui_is_ready()) { \
+    ui_print(x, ##__VA_ARGS__); \
+  } else \
+    Print(x "\n", ##__VA_ARGS__); \
 } while(0)
 
 #ifdef USE_UI

--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -1520,7 +1520,8 @@ EFI_STATUS android_image_start_buffer(
                 }
         }
 
-        debug(L"Loading the kernel");
+        debug(L"Loading the kernel after 10 seconds");
+        ui_wait_for_input(10);
         ret = handover_kernel(bootimage, parent_image);
         efi_perror(ret, L"handover_kernel");
 

--- a/libkernelflinger/ui.c
+++ b/libkernelflinger/ui.c
@@ -146,14 +146,14 @@ EFI_STATUS ui_init(UINTN *width_p, UINTN *height_p)
 	}
 
 	/* Initialize log area */
-	margin = min(graphic.width, graphic.height) / 10;
+	margin = min(graphic.width, graphic.height) / 20;
 	if (!default_textarea) {
 		font = ui_font_get("12x22");
 		if (!font)
 			return EFI_UNSUPPORTED;
 
-		x = margin / font->cheight;
-		y = (graphic.width - (2 * margin)) / font->cwidth;
+		x = (graphic.height - (2 * margin)) / font->cheight;
+		y = (graphic.width  - (2 * margin)) / font->cwidth;
 		default_textarea = ui_textarea_create(x, y, font, &COLOR_YELLOW, NULL);
 		if (!default_textarea) {
 			efi_perror(EFI_OUT_OF_RESOURCES, L"Failed to build the textarea");
@@ -161,7 +161,7 @@ EFI_STATUS ui_init(UINTN *width_p, UINTN *height_p)
 		}
 
 		default_textarea_x = margin;
-		default_textarea_y = graphic.height - margin;
+		default_textarea_y = margin;
 	}
 
 	*width_p = graphic.width;


### PR DESCRIPTION
Useful for no serial port platform.
Enlarge the UI log range.
Wait for 10 seconds before start Linux kernel, used for check the log.

Signed-off-by: Ming Tan <ming.tan@intel.com>