### PR TITLE
[DO NOT MERGE] Add kernel command line ignore_loglevel printk.devkmsg=on

### DIFF
--- a/libkernelflinger/android.c
+++ b/libkernelflinger/android.c
@@ -1025,6 +1025,8 @@ static EFI_STATUS setup_command_line(
                 goto out;
         }
 
+        prepend_command_line(&cmdline16, L"ignore_loglevel printk.devkmsg=on");
+
         ret = prepend_command_line(&cmdline16, L"androidboot.bootreason=%s", bootreason);
         if (EFI_ERROR(ret))
                 goto out;


### PR DESCRIPTION
It is useful for debug.

Signed-off-by: Ming Tan <ming.tan@intel.com>