### PR TITLE
remove some redefinations

### DIFF
--- a/libkernelflinger/protocol/CardInfo.h
+++ b/libkernelflinger/protocol/CardInfo.h
@@ -72,11 +72,13 @@ typedef struct {
 	UINT8  Command_Status;
 } TASK_FILE;
 
+#ifndef _DEVPATH_H
 typedef struct {
 	UINT8 Type;
 	UINT8 SubType;
 	UINT8 Length[2];
 } EFI_DEVICE_PATH_PROTOCOL;
+#endif
 
 typedef struct {
 	UINT16  Reserved0[10];

--- a/libkernelflinger/protocol/DevicePath.h
+++ b/libkernelflinger/protocol/DevicePath.h
@@ -37,11 +37,13 @@ Abstract:
 
 #pragma pack(1)
 
+#ifndef _DEVPATH_H
 typedef struct {
   UINT8 Type;
   UINT8 SubType;
   UINT8 Length[2];
 } EFI_DEVICE_PATH_PROTOCOL;
+#endif
 
 #pragma pack()
 


### PR DESCRIPTION
When gnu-efi upgraded to 3.0.9, some definations in kernelflinger
have already defined in gnu-efi

Tracked-On: OAM-84329
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>