### PR TITLE
Add trusty seed support on EFI platform

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -288,6 +288,8 @@ ifeq ($(BOARD_AVB_ENABLE),true)
 LOCAL_STATIC_LIBRARIES += libavb_kernelflinger-$(TARGET_BUILD_VARIANT)
 endif
 
+LOCAL_C_INCLUDES += \
+	$(addprefix $(LOCAL_PATH)/,libkernelflinger)
 include $(BUILD_EFI_EXECUTABLE)  # For kernelflinger-$(TARGET_BUILD_VARIANT)
 
 

--- a/kernelflinger.c
+++ b/kernelflinger.c
@@ -72,6 +72,7 @@
 #ifdef USE_TPM
 #include "tpm2_security.h"
 #endif
+#include "security_efi.h"
 
 /* Ensure this is embedded in the EFI binary somewhere */
 static const CHAR16 __attribute__((used)) magic[] = L"### kernelflinger ###";
@@ -1112,6 +1113,9 @@ static VOID enter_fastboot_mode(UINT8 boot_state)
 	set_efi_variable(&fastboot_guid, BOOT_STATE_VAR, sizeof(boot_state),
 			&boot_state, FALSE, TRUE);
 	set_oemvars_update(TRUE);
+
+	//stop bootloader seed protocol when entering fastboot mode
+	stop_bls_proto();
 
 	for (;;) {
 		target = UNKNOWN_TARGET;

--- a/libkernelflinger/security_efi.h
+++ b/libkernelflinger/security_efi.h
@@ -47,4 +47,6 @@ typedef struct {
 
 EFI_STATUS get_seeds(IN UINT32 *num_seeds, OUT VOID *seed_list);
 
+EFI_STATUS stop_bls_proto(void);
+
 #endif // _SECURITY_EFI_H_

--- a/libkernelflinger/trusty_efi.c
+++ b/libkernelflinger/trusty_efi.c
@@ -400,6 +400,7 @@ EFI_STATUS start_trusty(VOID *tosimage)
                 return EFI_INVALID_PARAMETER;
 
         ret = start_tos_image(tosimage);
+        stop_bls_proto();
         if (EFI_ERROR(ret)) {
             efi_perror(ret, L"Failed to launch tos image");
             return ret;


### PR DESCRIPTION
Use bootloader seed protocol to get the
cse seed from bios, also get the rpmb key.
The seed and rpmb keys are passed to trusty
via the tos startup info data structure.

Change-Id: I569f7988bd1b6e7a26d44829ab560af5174670fa
Tracked-On: OAM-XXXXX
Signed-off-by: gli41 <genshen.li@intel.com>