### PR TITLE
Use borningssl lib to decode BOKF.bin

### DIFF
--- a/libkernelflinger/bokf.h
+++ b/libkernelflinger/bokf.h
@@ -1,0 +1,19 @@
+#ifndef _BOKF_H_
+#define _BOKF_H_
+#include <openssl/asn1.h>
+#include <openssl/asn1t.h>
+#include <openssl/conf.h>
+typedef struct BOKF_st {
+	X509 *cert;
+	ASN1_OCTET_STRING *data;
+    ASN1_OCTET_STRING *enc_digest;
+}BOKF;
+DECLARE_ASN1_FUNCTIONS(BOKF)
+
+ASN1_SEQUENCE(BOKF) = {
+ASN1_SIMPLE(BOKF, cert, X509),
+ASN1_SIMPLE(BOKF, data, ASN1_OCTET_STRING),
+ASN1_SIMPLE(BOKF, enc_digest, ASN1_OCTET_STRING),
+} ASN1_SEQUENCE_END(BOKF)
+IMPLEMENT_ASN1_FUNCTIONS(BOKF)
+#endif

--- a/libsslsupport/borningssl/sys/syscall.h
+++ b/libsslsupport/borningssl/sys/syscall.h
@@ -2,3 +2,4 @@
 function needed for compiling borningssl on Android O
 */
 long syscall(long __number, ...){return 0;};
+void perror(const char* __msg){Print("error message :%s",__msg);};


### PR DESCRIPTION
we define bokf struct to replace pkcs7. so what
we change is in order to decode bokf format when
bootloader policy open

Change-Id: I1fc2b2a4702a9b9e0abb08a60a711c0d3aff3a19
Tracked-On: OAM-83718
Signed-off-by: zhang,xuepeng <xuepeng.zhang@intel.com>